### PR TITLE
Add dark mode toggle

### DIFF
--- a/codex/postcss.config.js
+++ b/codex/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/codex/src/app.jsx
+++ b/codex/src/app.jsx
@@ -1,11 +1,52 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { ThemeProvider, createTheme, CssBaseline, IconButton } from '@mui/material';
+import { DarkMode, LightMode } from '@mui/icons-material';
 import TimeboxTimer from './timeboxTimer';
 
 function App() {
+  const [darkMode, setDarkMode] = useState(false);
+
+  const theme = useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode: darkMode ? 'dark' : 'light',
+        },
+      }),
+    [darkMode],
+  );
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', darkMode);
+  }, [darkMode]);
+
+  const toggleDarkMode = () => {
+    setDarkMode((prev) => !prev);
+  };
+
   return (
-    <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#fafbfc' }}>
-      <TimeboxTimer />
-    </div>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <div
+        className="bg-gray-100 dark:bg-gray-800"
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          position: 'relative',
+        }}
+      >
+        <IconButton
+          aria-label="toggle dark mode"
+          onClick={toggleDarkMode}
+          sx={{ position: 'absolute', top: 8, right: 8 }}
+        >
+          {darkMode ? <LightMode /> : <DarkMode />}
+        </IconButton>
+        <TimeboxTimer />
+      </div>
+    </ThemeProvider>
   );
 }
 

--- a/codex/src/index.css
+++ b/codex/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/codex/src/main.jsx
+++ b/codex/src/main.jsx
@@ -1,8 +1,9 @@
-import {StyledEngineProvider} from '@mui/material/styles';
+import { StyledEngineProvider } from '@mui/material/styles';
 import GlobalStyles from '@mui/material/GlobalStyles';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/codex/tailwind.config.js
+++ b/codex/tailwind.config.js
@@ -1,0 +1,8 @@
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind for class-based dark mode
- set up PostCSS for Tailwind
- include Tailwind CSS in the app
- import styles in the entry file
- add MUI theme with light/dark support and a toggle button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686b7cce4b3c832a98ae52585bef1cf2