### PR TITLE
Add dark mode with Tailwind and MUI toggle

### DIFF
--- a/codex/postcss.config.js
+++ b/codex/postcss.config.js
@@ -1,0 +1,7 @@
+/* eslint-env node */
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/codex/src/app.jsx
+++ b/codex/src/app.jsx
@@ -1,11 +1,38 @@
-import React from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import IconButton from '@mui/material/IconButton';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import LightModeIcon from '@mui/icons-material/LightMode';
 import TimeboxTimer from './timeboxTimer';
 
 function App() {
+  const [darkMode, setDarkMode] = useState(false);
+
+  const theme = useMemo(() => createTheme({
+    palette: { mode: darkMode ? 'dark' : 'light' },
+  }), [darkMode]);
+
+  useEffect(() => {
+    if (darkMode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [darkMode]);
+
+  const toggleDarkMode = () => setDarkMode(prev => !prev);
+
   return (
-    <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', background: '#fafbfc' }}>
-      <TimeboxTimer />
-    </div>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <div className="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 min-h-screen flex items-center justify-center" style={{ position: 'relative' }}>
+        <IconButton onClick={toggleDarkMode} style={{ position: 'absolute', top: 16, right: 16 }} color="inherit">
+          {darkMode ? <LightModeIcon /> : <DarkModeIcon />}
+        </IconButton>
+        <TimeboxTimer />
+      </div>
+    </ThemeProvider>
   );
 }
 

--- a/codex/src/index.css
+++ b/codex/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/codex/src/main.jsx
+++ b/codex/src/main.jsx
@@ -1,8 +1,9 @@
-import {StyledEngineProvider} from '@mui/material/styles';
+import { StyledEngineProvider } from '@mui/material/styles';
 import GlobalStyles from '@mui/material/GlobalStyles';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/codex/src/timeboxTimer.jsx
+++ b/codex/src/timeboxTimer.jsx
@@ -31,27 +31,30 @@ function TimeboxTimer() {
   };
 
   return (
-    <div style={{
-      background: '#fff',
-      borderRadius: '18px',
-      boxShadow: '0 4px 24px rgba(0,0,0,0.10)',
-      border: '1.5px solid #e5e7eb',
-      padding: '2.5rem 2.5rem 2rem 2.5rem',
-      minWidth: 370,
-      maxWidth: 400,
-      width: 370,
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'stretch',
-      gap: '1.5rem',
-      margin: '0 auto',
-    }}>
+    <div
+      className="dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
+      style={{
+        background: '#fff',
+        borderRadius: '18px',
+        boxShadow: '0 4px 24px rgba(0,0,0,0.10)',
+        border: '1.5px solid #e5e7eb',
+        padding: '2.5rem 2.5rem 2rem 2.5rem',
+        minWidth: 370,
+        maxWidth: 400,
+        width: 370,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'stretch',
+        gap: '1.5rem',
+        margin: '0 auto',
+      }}
+    >
       <div style={{ textAlign: 'center', marginBottom: 8 }}>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, marginBottom: 2 }}>
           <span style={{ fontSize: 28 }}>⏱</span>
           <span style={{ fontSize: 28, fontWeight: 700 }}>Timebox Timer</span>
         </div>
-        <div style={{ color: '#6b7280', fontSize: 16, marginTop: 2 }}>Focus on one task at a time</div>
+        <div className="dark:text-gray-400" style={{ color: '#6b7280', fontSize: 16, marginTop: 2 }}>Focus on one task at a time</div>
       </div>
       
       <div>
@@ -100,6 +103,7 @@ function TimeboxTimer() {
         />
         {!isRunning && (
           <button
+            className="dark:bg-gray-700"
             style={{
               width: '100%',
               background: '#111827',
@@ -130,16 +134,17 @@ function TimeboxTimer() {
           textAlign: 'center',
           border: '1px solid #e5e7eb',
         }}>
-          <div style={{ color: '#6b7280', fontSize: 17, marginBottom: 2 }}>
-            Current Task: <span style={{ fontWeight: 600, color: '#111827' }}>{task}</span>
-          </div>
+        <div className="dark:text-gray-400" style={{ color: '#6b7280', fontSize: 17, marginBottom: 2 }}>
+          Current Task: <span style={{ fontWeight: 600, color: '#111827' }}>{task}</span>
+        </div>
           <div style={{ fontSize: 44, fontWeight: 700, letterSpacing: 1, margin: '8px 0' }}>{formatTime(timeLeft)}</div>
-          <div style={{ color: '#6b7280', fontSize: 15 }}>Time remaining</div>
+          <div className="dark:text-gray-400" style={{ color: '#6b7280', fontSize: 15 }}>Time remaining</div>
         </div>
       )}
 
       {isRunning && (
         <button
+          className="dark:bg-gray-600"
           style={{
             width: '100%',
             background: '#9ca3af',
@@ -158,7 +163,7 @@ function TimeboxTimer() {
         </button>
       )}
 
-      <div style={{ textAlign: 'center', color: '#6b7280', fontSize: 15, marginTop: isRunning ? 8 : 0, minHeight: 24 }}>
+      <div className="dark:text-gray-400" style={{ textAlign: 'center', color: '#6b7280', fontSize: 15, marginTop: isRunning ? 8 : 0, minHeight: 24 }}>
         {isRunning ? 'Stay focused on your current task!' : ''}
       </div>
     </div>

--- a/codex/tailwind.config.js
+++ b/codex/tailwind.config.js
@@ -1,0 +1,9 @@
+/* eslint-env node */
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind setup and enable class-based dark mode
- implement MUI theme switcher with a toggle button
- import global Tailwind CSS
- adjust timer styles for dark mode

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686b7cce4b3c832a98ae52585bef1cf2